### PR TITLE
Make parameters optional and add an usage overview.

### DIFF
--- a/hue/hue.tcl
+++ b/hue/hue.tcl
@@ -2,12 +2,36 @@
 
 source /usr/local/addons/hue/config.tcl
 
+if { $argc < 2 } {
+  puts "Usage: hue.tcl lamp state brightness saturation hue transition_time"
+  puts ""
+  puts "  lamp                  Number of the lamp"
+  puts "  state                 on/off - true/false"
+  puts "  brightness            0-255"
+  puts "  saturation            0-255"
+  puts "  hue                   0-65535 0=red, 25500=green, 46920=blue"
+  puts "  transition_time       1/10s"
+  exit 1
+}
+
 set lamp [lindex $argv 0]
 set state [lindex $argv 1]
-set bri [lindex $argv 2]
-set sat [lindex $argv 3]
-set hue [lindex $argv 4]
-set tt [lindex $argv 5]
+set bri 255
+set sat 0
+set hue 30000
+set tt 30
+if { $argc >= 3 } {
+  set bri [lindex $argv 2]
+}
+if { $argc >= 4 } {
+  set sat [lindex $argv 3]
+}
+if { $argc >= 5 } {
+  set hue [lindex $argv 4]
+}
+if { $argc >= 6 } {
+  set tt [lindex $argv 5]
+}
 
 set url "http://$ip:80/api/$user/lights/$lamp/state"
 


### PR DESCRIPTION
This changes allows easy turn off / turn on of lamps e.g.
/usr/local/addons/hue/hue.tcl 1 false
/usr/local/addons/hue/hue.tcl 1 true